### PR TITLE
Add taskmaster config CLI

### DIFF
--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -14,6 +14,7 @@ if (major < MIN_NODE_VERSION.major ||
 import { program } from 'commander';
 import fs from 'fs';
 import path from 'path';
+import { readConfig, updateConfig } from '../taskmaster/config.js';
 import { 
   initializeData, 
   generatePrompt, 
@@ -173,6 +174,33 @@ program
 
     fs.writeFileSync(options.output, JSON.stringify(template, null, 2));
     console.log(`Template saved to: ${options.output}`);
+  });
+
+const taskmaster = program.command('taskmaster').description('Taskmaster utilities');
+
+taskmaster
+  .command('get [key]')
+  .description('View configuration')
+  .action((key) => {
+    const config = readConfig();
+    if (key) {
+      console.log(config[key]);
+    } else {
+      console.log(JSON.stringify(config, null, 2));
+    }
+  });
+
+taskmaster
+  .command('set <key> <value>')
+  .description('Set configuration value')
+  .action((key, value) => {
+    try {
+      updateConfig({ [key]: value });
+      console.log(`Updated ${key} to ${value}`);
+    } catch (err) {
+      console.error('Error:', err.message);
+      process.exit(1);
+    }
   });
 
 program.parse();

--- a/src/taskmaster/config.js
+++ b/src/taskmaster/config.js
@@ -1,0 +1,48 @@
+import fs from 'fs';
+import path from 'path';
+
+const CONFIG_FILE = path.resolve(process.cwd(), 'taskmaster.config.json');
+
+const defaultConfig = {
+  defaultPriority: 'medium',
+  defaultComplexity: 'medium',
+  outputDir: './prompts'
+};
+
+export function readConfig() {
+  if (!fs.existsSync(CONFIG_FILE)) {
+    return { ...defaultConfig };
+  }
+  try {
+    const data = JSON.parse(fs.readFileSync(CONFIG_FILE, 'utf8'));
+    return { ...defaultConfig, ...data };
+  } catch (err) {
+    throw new Error(`Failed to parse config: ${err.message}`);
+  }
+}
+
+export function validateConfig(config) {
+  const errors = [];
+  if (config.defaultPriority && !['low', 'medium', 'high', 'critical'].includes(config.defaultPriority)) {
+    errors.push('Invalid defaultPriority');
+  }
+  if (config.defaultComplexity && !['low', 'medium', 'high'].includes(config.defaultComplexity)) {
+    errors.push('Invalid defaultComplexity');
+  }
+  if (config.outputDir && typeof config.outputDir !== 'string') {
+    errors.push('Invalid outputDir');
+  }
+  return { isValid: errors.length === 0, errors };
+}
+
+export function updateConfig(updates) {
+  const current = readConfig();
+  const newConfig = { ...current, ...updates };
+  const validation = validateConfig(newConfig);
+  if (!validation.isValid) {
+    throw new Error(`Config validation failed: ${validation.errors.join(', ')}`);
+  }
+  fs.writeFileSync(CONFIG_FILE, JSON.stringify(newConfig, null, 2));
+  return newConfig;
+}
+

--- a/taskmaster.config.json
+++ b/taskmaster.config.json
@@ -1,0 +1,5 @@
+{
+  "defaultPriority": "medium",
+  "defaultComplexity": "medium",
+  "outputDir": "./prompts"
+}

--- a/test/taskmasterConfig.test.js
+++ b/test/taskmasterConfig.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { readConfig, validateConfig, updateConfig } from '../src/taskmaster/config.js';
+import { execFileSync } from 'child_process';
+
+const CONFIG_PATH = path.resolve(process.cwd(), 'taskmaster.config.json');
+
+const backup = fs.existsSync(CONFIG_PATH) ? fs.readFileSync(CONFIG_PATH, 'utf8') : null;
+
+beforeEach(() => {
+  if (backup) fs.writeFileSync(CONFIG_PATH, backup);
+});
+
+afterEach(() => {
+  if (backup) fs.writeFileSync(CONFIG_PATH, backup);
+});
+
+describe('taskmaster config helpers', () => {
+  it('reads default config', () => {
+    const cfg = readConfig();
+    expect(cfg.defaultPriority).toBeDefined();
+  });
+
+  it('validates correct config', () => {
+    const result = validateConfig({ defaultPriority: 'low', defaultComplexity: 'high' });
+    expect(result.isValid).toBe(true);
+  });
+
+  it('updates config file', () => {
+    const updated = updateConfig({ defaultPriority: 'high' });
+    const reload = readConfig();
+    expect(updated.defaultPriority).toBe('high');
+    expect(reload.defaultPriority).toBe('high');
+  });
+});
+
+describe('taskmaster CLI', () => {
+  it('prints config', () => {
+    const output = execFileSync('node', ['bin/prompter', 'taskmaster', 'get']).toString();
+    const cfg = JSON.parse(output);
+    expect(cfg.defaultPriority).toBeDefined();
+  });
+
+  it('sets config via CLI', () => {
+    execFileSync('node', ['bin/prompter', 'taskmaster', 'set', 'defaultComplexity', 'low']);
+    const cfg = readConfig();
+    expect(cfg.defaultComplexity).toBe('low');
+  });
+});


### PR DESCRIPTION
## Summary
- add `taskmaster.config.json` for default priority/complexity and outputDir
- create `src/taskmaster/config.js` helpers to read/validate/update config
- extend CLI with `taskmaster get|set` commands
- test configuration helpers and CLI integration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864578f8aec8328ba5138751587bfae