### PR TITLE
Add environment detection scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,18 @@ Task Master reads options from environment variables in a `.env` file:
 4. Write tests
 5. Submit a pull request
 
+## Environment Detection
+
+This package automatically detects whether a project is using Node.js,
+Python, or a combination of both. The detection script runs during the
+`npm install` step. You can also run it manually:
+
+```bash
+node index.js
+```
+
+Sample projects for manual testing are provided in the `sandbox/` directory.
+
 ## License
 
 MIT License - see LICENSE file for details.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import { detectEnvironment } from './lib/env.js';
+
+const env = detectEnvironment(process.cwd());
+
+console.log('Environment detected:');
+console.log(env);

--- a/lib/env.js
+++ b/lib/env.js
@@ -1,0 +1,27 @@
+import fs from 'fs';
+import path from 'path';
+
+export function detectEnvironment(cwd) {
+  const files = fs.readdirSync(cwd);
+  const hasFile = (filename) => files.includes(filename);
+
+  return {
+    isPython: hasFile('requirements.txt') || hasFile('pyproject.toml'),
+    isNode: hasFile('package.json'),
+    hasPoetry:
+      hasFile('pyproject.toml') &&
+      fs.readFileSync(path.join(cwd, 'pyproject.toml'), 'utf8').includes('[tool.poetry]'),
+    hasPipenv: hasFile('Pipfile'),
+    environmentType: (() => {
+      if (hasFile('package.json') && (hasFile('requirements.txt') || hasFile('pyproject.toml'))) {
+        return 'mixed';
+      } else if (hasFile('package.json')) {
+        return 'node';
+      } else if (hasFile('requirements.txt') || hasFile('pyproject.toml')) {
+        return 'python';
+      } else {
+        return 'unknown';
+      }
+    })(),
+  };
+}

--- a/package.json
+++ b/package.json
@@ -60,7 +60,10 @@
     "src/",
     "README.md",
     "LICENSE",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "index.js",
+    "scripts/postinstall.js",
+    "lib/env.js"
   ],
   "engines": {
     "node": ">=16.0.0"
@@ -87,7 +90,8 @@
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs",
-    "update:task-master": "node scripts/update-task-master.js"
+    "update:task-master": "node scripts/update-task-master.js",
+    "postinstall": "node scripts/postinstall.js"
   },
   "dependencies": {
     "claude-task-master": "^1.6.4",

--- a/sandbox/mixed_project/package.json
+++ b/sandbox/mixed_project/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "mixed-project",
+  "version": "1.0.0",
+  "description": "Project with both Node and Python",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "lodash": "^4.17.21"
+  }
+}

--- a/sandbox/mixed_project/pyproject.toml
+++ b/sandbox/mixed_project/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.poetry]
+name = "mixed-python-node-project"
+version = "0.1.0"
+description = "Python part of the mixed environment"
+authors = ["Your Name <your@email.com>"]

--- a/sandbox/mixed_project/requirements.txt
+++ b/sandbox/mixed_project/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+pandas

--- a/sandbox/node_project/package.json
+++ b/sandbox/node_project/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "sample-node-project",
+  "version": "1.0.0",
+  "description": "Sample Node.js-only project",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {}
+}

--- a/sandbox/python_project/pyproject.toml
+++ b/sandbox/python_project/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.poetry]
+name = "sample-python-project"
+version = "0.1.0"
+description = "Sample Python-only project"
+authors = ["Your Name <your@email.com>"]

--- a/sandbox/python_project/requirements.txt
+++ b/sandbox/python_project/requirements.txt
@@ -1,0 +1,2 @@
+flask
+requests

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,6 @@
+import { detectEnvironment } from '../lib/env.js';
+
+const env = detectEnvironment(process.cwd());
+
+console.log('[agent-prompt-tool] Environment detected:');
+console.log(env);


### PR DESCRIPTION
## Summary
- implement env detection helper
- add simple CLI script
- run detection in `postinstall`
- add sandbox projects for manual testing
- document environment detection usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68645d182424832886a6ca1ff46456e4