### PR TITLE
Add PHP Laravel and Go sandbox projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ node index.js
 ```
 
 Sample projects for manual testing are provided in the `sandbox/` directory.
+These include basic Node.js, Python, mixed language, Go, and Laravel PHP
+setups for quick environment detection tests.
 
 ## License
 

--- a/sandbox/go_project/go.mod
+++ b/sandbox/go_project/go.mod
@@ -1,0 +1,7 @@
+module example.com/sample
+
+go 1.20
+
+require (
+github.com/gin-gonic/gin v1.9.0
+)

--- a/sandbox/php_laravel_project/composer.json
+++ b/sandbox/php_laravel_project/composer.json
@@ -1,0 +1,7 @@
+{
+  "name": "sample-laravel-project",
+  "type": "project",
+  "require": {
+    "laravel/framework": "^10.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add `php_laravel_project` sample with composer.json
- add `go_project` sample with go.mod
- mention new sandbox projects in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68645fb307ac8328bce5511d056c41f6