### PR TITLE
Fix npm ci by keeping lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
         # Remove npm cache to avoid optional dependency issues
         cache: ''
     
-    - name: Clean node_modules and package-lock.json
+    - name: Clean node_modules
       run: |
-        rm -rf node_modules package-lock.json
+        rm -rf node_modules
     
     - name: Install dependencies
       run: npm ci
@@ -59,9 +59,9 @@ jobs:
         # Remove npm cache to avoid optional dependency issues
         cache: ''
     
-    - name: Clean node_modules and package-lock.json
+    - name: Clean node_modules
       run: |
-        rm -rf node_modules package-lock.json
+        rm -rf node_modules
     
     - name: Install dependencies
       run: npm ci


### PR DESCRIPTION
## Summary
- adjust CI workflow to keep `package-lock.json` so `npm ci` works

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686461a81d2483288c90308ee0ac3dfc