### PR TITLE
Add documentation index

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ const prompt = generator.generate({
 }, 'security-audit');
 ```
 
+## Documentation
+
+See [docs/index.md](docs/index.md) for additional guides.
+
 ## Available Task Types
 
 - **implementation**: Feature development and system building

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,8 @@
+# Documentation Index
+
+This directory contains guides and references for the Prompter Framework.
+
+- [Migration Guide](guides/migration.md) - Steps for upgrading from the original `ai-prompt-generator` package.
+- [Plugin Development Guide](guides/plugin-development.md) - Instructions for creating custom plugins.
+
+For general usage instructions and installation steps, see the [project README](../README.md).


### PR DESCRIPTION
## Summary
- create `docs/index.md` listing guides
- link to docs index from README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864665800848328bc0ee32e4675c4c1