### PR TITLE
Add API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ const prompt = generator.generate({
 
 ## Documentation
 
-See [docs/index.md](docs/index.md) for additional guides.
+See [docs/index.md](docs/index.md) for additional guides and the [API reference](docs/api/index.md).
 
 ## Available Task Types
 

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -1,0 +1,70 @@
+# CLI Commands
+
+The `prompter` binary provides access to prompt generation and configuration utilities.
+
+```bash
+npx prompter-framework <command> [options]
+```
+
+## `generate`
+
+Generate an AI agent prompt from command line arguments or a JSON file.
+
+### Options
+
+- `-t, --type <type>` – task type to use
+- `-T, --title <title>` – task title
+- `-i, --id <id>` – optional task ID
+- `-p, --priority <level>` – priority (`low`, `medium`, `high`, `critical`)
+- `-c, --complexity <level>` – complexity (`low`, `medium`, `high`)
+- `-r, --requirements <items...>` – one or more core requirements
+- `-C, --constraints <items...>` – technical constraints
+- `-R, --resources <items...>` – resource references
+- `-o, --output <file>` – write the prompt to a file
+- `-j, --json <file>` – load task data from a JSON template
+- `--list-types` – print available task types
+
+### Example
+
+```bash
+prompter generate \
+  --type implementation \
+  --title "Add MFA" \
+  --requirements "TOTP" "SMS backup" \
+  --constraints "Integrate with existing auth"
+```
+
+## `template`
+
+Create a JSON template for task input.
+
+### Options
+
+- `-t, --type <type>` – task type for the template (default `implementation`)
+- `-o, --output <file>` – file path for the generated template (default `task-template.json`)
+
+### Example
+
+```bash
+prompter template --type debugging --output debug.json
+```
+
+## `taskmaster`
+
+Utility commands for the bundled Task Master integration.
+
+### `get [key]`
+
+View configuration values. Without a key, prints the entire config.
+
+```bash
+prompter taskmaster get
+```
+
+### `set <key> <value>`
+
+Update a configuration value.
+
+```bash
+prompter taskmaster set DEFAULT_PRIORITY high
+```

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,8 @@
+# API Reference
+
+This section documents the programmatic APIs and CLI commands provided by the Prompter Framework.
+
+- [PromptGenerator](promptgenerator.md) - Generate prompts programmatically.
+- [Plugin System](plugins.md) - Extend functionality with plugins.
+- [CLI Commands](cli.md) - Use the `prompter` command line tool.
+

--- a/docs/api/plugins.md
+++ b/docs/api/plugins.md
@@ -1,0 +1,41 @@
+# Plugin System
+
+The framework supports plugins that add new task types and templates.
+
+## `PluginManager`
+
+```javascript
+import { PluginManager } from 'prompter-framework';
+```
+
+### Methods
+
+- `use(plugin)` – register a plugin object. Returns the manager instance.
+- `getTaskTypes()` – returns a map of all custom task types provided by plugins.
+- `getTemplates()` – returns a map of custom templates.
+- `hasPlugin(name)` – checks whether a plugin with `name` is registered.
+
+## `createPlugin(config)`
+
+Helper to create plugin objects.
+`config` should include:
+
+- `name` – unique plugin name
+- `taskTypes` – map of task type keys to display names
+- `templates` – map of task type keys to template definitions
+
+```javascript
+import { createPlugin } from 'prompter-framework';
+
+const myPlugin = createPlugin({
+  name: 'security-audit',
+  taskTypes: {
+    'security-audit': 'Security Audit'
+  },
+  templates: {
+    'security-audit': { /* template data */ }
+  }
+});
+```
+
+Use `PluginManager` or `PromptGenerator#use` to register the plugin.

--- a/docs/api/promptgenerator.md
+++ b/docs/api/promptgenerator.md
@@ -1,0 +1,49 @@
+# PromptGenerator Class
+
+The `PromptGenerator` class is the main interface for creating task prompts programmatically.
+
+```javascript
+import { PromptGenerator } from 'prompter-framework';
+```
+
+## Constructor
+
+```javascript
+const generator = new PromptGenerator(options?);
+```
+
+- `options.defaultPriority` – default priority for tasks (`low`, `medium`, `high`, `critical`)
+- `options.defaultComplexity` – default complexity (`low`, `medium`, `high`)
+
+## Methods
+
+### `use(plugin)`
+
+Registers a plugin and merges its task types and templates.
+Returns the generator instance for chaining.
+
+### `generate(formData, taskType)`
+
+Validates the provided data and builds a prompt using the template for `taskType`.
+Throws an error when validation fails or the task type is unknown.
+
+### `getAvailableTaskTypes()`
+
+Returns an array of all task type keys currently available, including those provided by plugins.
+
+### `getTemplate(taskType)`
+
+Returns the template object for `taskType` if it exists.
+
+## Example
+
+```javascript
+const generator = new PromptGenerator();
+const prompt = generator.generate({
+  taskTitle: 'Add Multi-Factor Authentication',
+  requirements: ['TOTP support', 'SMS backup'],
+  constraints: ['Must integrate with existing auth system']
+}, 'implementation');
+
+console.log(prompt);
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,5 +4,6 @@ This directory contains guides and references for the Prompter Framework.
 
 - [Migration Guide](guides/migration.md) - Steps for upgrading from the original `ai-prompt-generator` package.
 - [Plugin Development Guide](guides/plugin-development.md) - Instructions for creating custom plugins.
+- [API Reference](api/index.md) - Documentation for classes and CLI commands.
 
 For general usage instructions and installation steps, see the [project README](../README.md).


### PR DESCRIPTION
## Summary
- document the API under `docs/api`
- add references to the new docs from the README and docs index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864750fff8883288a35516d96553eb2